### PR TITLE
replace Hearth Kami with Monastery Swiftspear

### DIFF
--- a/cards.md
+++ b/cards.md
@@ -227,7 +227,6 @@
   - Shrapnel Blast (Mirrodin)
   - Slith Firewalker (Mirrodin)
   - Magma Jet (Fifth Dawn)
-  - Hearth Kami (Champions of Kamigawa)
   - Kiki-Jiki, Mirror Breaker (Champions of Kamigawa)
   - Tin Street Hooligan (Guildpact)
   - Bogardan Hellkite (Time Spiral)
@@ -249,6 +248,7 @@
   - Young Pyromancer (Magic 2014)
   - Harness by Force (Journey into Nyx)
   - Hordeling Outburst (Khans of Tarkir)
+  - Monastery Swiftspear (Khans of Tarkir)
 
 ### Green
 

--- a/index.html
+++ b/index.html
@@ -281,7 +281,6 @@
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Shrapnel%20Blast"><img src="http://mtgimage.com/setname/Mirrodin/Shrapnel%20Blast.jpg" alt="Shrapnel Blast"></a></li>
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Slith%20Firewalker"><img src="http://mtgimage.com/setname/Mirrodin/Slith%20Firewalker.jpg" alt="Slith Firewalker"></a></li>
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Magma%20Jet"><img src="http://mtgimage.com/setname/Fifth%20Dawn/Magma%20Jet.jpg" alt="Magma Jet"></a></li>
-    <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Hearth%20Kami"><img src="http://mtgimage.com/setname/Champions%20of%20Kamigawa/Hearth%20Kami.jpg" alt="Hearth Kami"></a></li>
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Kiki-Jiki%2C%20Mirror%20Breaker"><img src="http://mtgimage.com/setname/Champions%20of%20Kamigawa/Kiki-Jiki%2C%20Mirror%20Breaker.jpg" alt="Kiki-Jiki, Mirror Breaker"></a></li>
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Tin%20Street%20Hooligan"><img src="http://mtgimage.com/setname/Guildpact/Tin%20Street%20Hooligan.jpg" alt="Tin Street Hooligan"></a></li>
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Bogardan%20Hellkite"><img src="http://mtgimage.com/setname/Time%20Spiral/Bogardan%20Hellkite.jpg" alt="Bogardan Hellkite"></a></li>
@@ -303,6 +302,7 @@
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Young%20Pyromancer"><img src="http://mtgimage.com/setname/Magic%202014/Young%20Pyromancer.jpg" alt="Young Pyromancer"></a></li>
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Harness%20by%20Force"><img src="http://mtgimage.com/setname/Journey%20into%20Nyx/Harness%20by%20Force.jpg" alt="Harness by Force"></a></li>
     <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Hordeling%20Outburst"><img src="http://mtgimage.com/setname/Khans%20of%20Tarkir/Hordeling%20Outburst.jpg" alt="Hordeling Outburst"></a></li>
+    <li><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Monastery%20Swiftspear"><img src="http://mtgimage.com/setname/Khans%20of%20Tarkir/Monastery%20Swiftspear.jpg" alt="Monastery Swiftspear"></a></li>
   </ul>
   <div style="clear:left"></div>
   <h3 id="green">Green</h3>


### PR DESCRIPTION
![Monastery Swiftspear](http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=386608&type=card)

@weakplayer commented that we currently have a lot of artifact destruction. Hearth Kami can go, I think.
