### PR TITLE
replace Hall of Triumph with Relic of Progenitus

### DIFF
--- a/cards.md
+++ b/cards.md
@@ -391,11 +391,11 @@
   - [x] Pentad Prism (Fifth Dawn)
   - [x] Vedalken Shackles (Fifth Dawn)
   - [x] Sensei's Divining Top (Champions of Kamigawa)
+  - [ ] Relic of Progenitus (Shards of Alara)
   - [x] Molten-Tail Masticore (Scars of Mirrodin)
   - [x] Runechanter's Pike (Innistrad)
   - [x] Helvault (Dark Ascension)
   - [x] Pyromancer's Gauntlet (Magic 2014)
-  - [ ] Hall of Triumph (Journey into Nyx)
 
 ### Land
 

--- a/index.html
+++ b/index.html
@@ -451,11 +451,11 @@
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Pentad%20Prism"><img src="http://mtgimage.com/setname/Fifth%20Dawn/Pentad%20Prism.jpg" alt="Pentad Prism"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Vedalken%20Shackles"><img src="http://mtgimage.com/setname/Fifth%20Dawn/Vedalken%20Shackles.jpg" alt="Vedalken Shackles"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Sensei's%20Divining%20Top"><img src="http://mtgimage.com/setname/Champions%20of%20Kamigawa/Sensei's%20Divining%20Top.jpg" alt="Sensei's Divining Top"></a></li>
+    <li data-checked="false"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Relic%20of%20Progenitus"><img src="http://mtgimage.com/setname/Shards%20of%20Alara/Relic%20of%20Progenitus.jpg" alt="Relic of Progenitus"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Molten-Tail%20Masticore"><img src="http://mtgimage.com/setname/Scars%20of%20Mirrodin/Molten-Tail%20Masticore.jpg" alt="Molten-Tail Masticore"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Runechanter's%20Pike"><img src="http://mtgimage.com/setname/Innistrad/Runechanter's%20Pike.jpg" alt="Runechanter's Pike"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Helvault"><img src="http://mtgimage.com/setname/Dark%20Ascension/Helvault.jpg" alt="Helvault"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Pyromancer's%20Gauntlet"><img src="http://mtgimage.com/setname/Magic%202014/Pyromancer's%20Gauntlet.jpg" alt="Pyromancer's Gauntlet"></a></li>
-    <li data-checked="false"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Hall%20of%20Triumph"><img src="http://mtgimage.com/setname/Journey%20into%20Nyx/Hall%20of%20Triumph.jpg" alt="Hall of Triumph"></a></li>
   </ul>
   <div style="clear:left"></div>
   <h3 id="land">Land</h3>


### PR DESCRIPTION
![Relic of Progenitus](http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=174824&type=card)

I like Hall of Triumph, but don't have access to one. Relic interacts with many of the decks, and can be fetched by Trinket Mage.
