### PR TITLE
replace Roar of the Wurm with Courser of Kruphix

### DIFF
--- a/cards.md
+++ b/cards.md
@@ -282,7 +282,6 @@
   - [x] Thornscape Battlemage (Planeshift)
   - [x] Call of the Herd (Odyssey)
   - [x] Nimble Mongoose (Odyssey)
-  - [x] Roar of the Wurm (Odyssey)
   - [x] Werebear (Odyssey)
   - [x] Wild Mongrel (Odyssey)
   - [x] Basking Rootwalla (Torment)
@@ -311,6 +310,7 @@
   - [x] Thrun, the Last Troll (Mirrodin Besieged)
   - [x] Avacyn's Pilgrim (Innistrad)
   - [x] Sylvan Caryatid (Theros)
+  - [x] Courser of Kruphix (Born of the Gods)
   - [x] Hornet Queen (Magic 2015)
 
 ### Artifact

--- a/index.html
+++ b/index.html
@@ -334,7 +334,6 @@
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Thornscape%20Battlemage"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Thornscape%20Battlemage&amp;set=PS&amp;type=card" alt="Thornscape Battlemage"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Call%20of%20the%20Herd"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Call%20of%20the%20Herd&amp;set=OD&amp;type=card" alt="Call of the Herd"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Nimble%20Mongoose"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Nimble%20Mongoose&amp;set=OD&amp;type=card" alt="Nimble Mongoose"></a></li>
-    <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Roar%20of%20the%20Wurm"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Roar%20of%20the%20Wurm&amp;set=OD&amp;type=card" alt="Roar of the Wurm"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Werebear"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Werebear&amp;set=OD&amp;type=card" alt="Werebear"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Wild%20Mongrel"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Wild%20Mongrel&amp;set=OD&amp;type=card" alt="Wild Mongrel"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Basking%20Rootwalla"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Basking%20Rootwalla&amp;set=TOR&amp;type=card" alt="Basking Rootwalla"></a></li>
@@ -363,6 +362,7 @@
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Thrun%2C%20the%20Last%20Troll"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Thrun%2C%20the%20Last%20Troll&amp;set=MBS&amp;type=card" alt="Thrun, the Last Troll"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Avacyn's%20Pilgrim"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Avacyn's%20Pilgrim&amp;set=ISD&amp;type=card" alt="Avacyn's Pilgrim"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Sylvan%20Caryatid"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Sylvan%20Caryatid&amp;set=THS&amp;type=card" alt="Sylvan Caryatid"></a></li>
+    <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Courser%20of%20Kruphix"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Courser%20of%20Kruphix&amp;set=BNG&amp;type=card" alt="Courser of Kruphix"></a></li>
     <li data-checked="true"><a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?name=Hornet%20Queen"><img src="http://gatherer.wizards.com/Handlers/Image.ashx?name=Hornet%20Queen&amp;set=&amp;type=card" alt="Hornet Queen"></a></li>
   </ul>
   <div style="clear:left"></div>


### PR DESCRIPTION
[Roar of the Wurm](http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=29881) is far too narrow.
